### PR TITLE
Added paths to ignore for build workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'images/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'images/**'
 
 jobs:
   # ASWF docker images based build


### PR DESCRIPTION
It is un-necessary to trigger the build when updating documentation and media file(s). 
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-ignoring-paths

Signed-off-by: rlei-weta <rlei@wetafx.co.nz>