### PR TITLE
Added missing USD include and library search dirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Minimum CMake version aligned with release branch of USD.
-cmake_minimum_required(VERSION 3.12)
+# 3.13 for target_link_directories.
+cmake_minimum_required(VERSION 3.13)
 
 # Define project.
 project(

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are many other USD plugins available online - check out [USD Working Group
 
 The following dependencies are required:
 - C++ compiler
-- [CMake](https://cmake.org/documentation/) (3.12 or greater)
+- [CMake](https://cmake.org/documentation/) (3.13 or greater)
 - [USD](https://github.com/pixaranimationstudios/USD)
 - [Boost](https://boost.org) and [Intel TBB](https://www.threadingbuildingblocks.org/) (USD dependencies)
 

--- a/cmake/USDPluginTools.cmake
+++ b/cmake/USDPluginTools.cmake
@@ -179,6 +179,13 @@ function(_usd_library NAME)
             ${PYTHON_INCLUDE_DIR}
             ${Boost_INCLUDE_DIR}
             ${TBB_INCLUDE_DIRS}
+            ${USD_INCLUDE_DIR}
+    )
+
+    # Set-up library search path.
+    target_link_directories(${NAME}
+        PRIVATE
+            ${USD_LIBRARY_DIR}
     )
 
     # Link to libraries.
@@ -296,6 +303,12 @@ function(_usd_library NAME)
                     MFB_PACKAGE_NAME=${NAME}
                     MFB_ALT_PACKAGE_NAME=${NAME}
                     MFB_PACKAGE_MODULE=${PYTHON_MODULE_NAME}
+            )
+
+            # Set-up library search path.
+            target_link_directories(${PYLIB_NAME}
+                PRIVATE
+                    ${USD_LIBRARY_DIR}
             )
 
             # Apply link dependencies.


### PR DESCRIPTION
- Added USD_INCLUDE_DIR to C++ library's target_include_directories
- Added USD_LIBRARY_DIR to C++ & python module's target_link_directories
- Bumped minimum CMake version to 3.13 (target_link_directories)

Fixes #8

Signed-off-by: rlei-weta <rlei@wetafx.co.nz>