### PR TITLE
UsdviewTri: Example usdview plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Huge thanks to Pixar's USD team for providing a highly extensible platform!
 - [usdTriImaging](./src/usdTriImaging): A prim adapter which images the **Triangle** prim type.
 - [usdTriFileFormat](./src/usdTriFileFormat): A file format plugin which authors a triangular mesh for a `.triangle` payload.
 - [hdTri](./src/hdTri): A hydra renderer plugin which images a triangle (in the most direct sense).
+- [usdviewTri](./src/usdviewTri): An usdview plugin providing a menu command to define child Triangle prim(s) under selected paths.
 
 There are many other USD plugins available online - check out [USD Working Group: Projects & Resources](https://wiki.aswf.io/display/WGUSD/USD+Projects+and+Resources) for more!
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ In the viewport, a triangle should be centered at origin:
 Custom CMake macros are provided, for abstracting away USD plugin build intricacies:
 - `usd_shared_library`: [Example usage](./src/usdTri/CMakeLists.txt)
 - `usd_plugin`: [Example usage](./src/hdTri/CMakeLists.txt)
+- `usd_python_library`: [Example usage](./src/usdviewTri/CMakeLists.txt)
 - `usd_python_test`: [Example usage](./src/usdTri/tests/CMakeLists.txt)
 
 The interface of the above macros are largely based on those used throughout the [official USD project](https://github.com/PixarAnimationStudios/USD).

--- a/cmake/USDPluginTools.cmake
+++ b/cmake/USDPluginTools.cmake
@@ -134,6 +134,47 @@ function(usd_plugin NAME)
     )
 endfunction()
 
+# Public entry point for building python-and-resource-files only library.
+# This was _specifically_ exposed to produce plugins for usdview, but can be useful
+# for deploying python plugins in general that adhere to the installation structure
+# prescribed by USDPluginTools.
+#
+function(usd_python_library NAME)
+    set(options)
+
+    set(oneValueArgs
+    )
+
+    set(multiValueArgs
+        PYTHON_INSTALL_PREFIX
+        PYTHON_FILES
+        RESOURCE_FILES
+    )
+
+    cmake_parse_arguments(args
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    if (ENABLE_PYTHON_SUPPORT)
+        _usd_python_module(${NAME}
+            PYTHON_INSTALL_PREFIX
+                ${args_PYTHON_INSTALL_PREFIX}
+            PYTHON_FILES
+                ${args_PYTHON_FILES}
+        )
+
+        _usd_install_resource_files(${NAME}
+            TYPE
+                SHARED
+            RESOURCE_FILES
+                ${args_RESOURCE_FILES}
+        )
+    endif()
+endfunction()
+
 # Adds a USD-based python test which is executed by CTest.
 # The python file is simply executed by the python interpreter
 # with no special arguments.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(ORGANIZATION "usdpluginexamples")
 
 # Build & install libraries.
 add_subdirectory(usdTri)
+add_subdirectory(usdviewTri)
 
 # Build & install plugins.
 add_subdirectory(usdTriImaging)

--- a/src/usdviewTri/CMakeLists.txt
+++ b/src/usdviewTri/CMakeLists.txt
@@ -1,0 +1,10 @@
+usd_python_library(usdviewTri
+    PYTHON_INSTALL_PREFIX
+        ${ORGANIZATION}
+
+    PYTHON_FILES
+        __init__.py
+
+    RESOURCE_FILES
+        plugInfo.json
+)

--- a/src/usdviewTri/__init__.py
+++ b/src/usdviewTri/__init__.py
@@ -1,0 +1,23 @@
+from pxr import Tf
+from pxr.Usdviewq.plugin import PluginContainer
+
+
+def DefineChildTriangle(usdviewApi):
+    for selectedPath in usdviewApi.selectedPaths:
+        usdviewApi.stage.DefinePrim(selectedPath.AppendChild("triangle"), "Triangle")
+
+
+class UsdviewTriPluginContainer(PluginContainer):
+
+    def registerPlugins(self, plugRegistry, usdviewApi):
+        self._defineChildTriangle = plugRegistry.registerCommandPlugin(
+            "UsdviewTriPluginContainer.DefineChildTriangle",
+            "Define Child Triangle",
+            DefineChildTriangle)
+
+    def configureView(self, plugRegistry, plugUIBuilder):
+        triMenu = plugUIBuilder.findOrCreateMenu("Tri")
+        triMenu.addItem(self._defineChildTriangle)
+
+
+Tf.Type.Define(UsdviewTriPluginContainer)

--- a/src/usdviewTri/plugInfo.json
+++ b/src/usdviewTri/plugInfo.json
@@ -1,0 +1,16 @@
+{
+    "Plugins": [
+        {
+            "Type": "python",
+            "Name": "usdpluginexamples.UsdviewTri",
+            "Info": {
+                "Types": {
+                    "usdpluginexamples.UsdviewTri.UsdviewTriPluginContainer": {
+                        "bases": ["pxr.Usdviewq.plugin.PluginContainer"],
+                        "displayName": "Usdview Tri Plugin"
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added an example usdview plugin for defining child triangles under selected paths
in the outliner.

A new "usd_python_library" CMake function has been exposed to support
installation of a python-and-resource-files library, which is what the
UsdviewTri plugin uses.

Signed-off-by: rlei-weta <rlei@wetafx.co.nz>