### PR TITLE
Added "usd_executable" CMake utility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ In the viewport, a triangle should be centered at origin:
 Custom CMake functions are provided, for abstracting away USD plugin build intricacies:
 - `usd_shared_library`: [Example usage](./src/usdTri/CMakeLists.txt)
 - `usd_plugin`: [Example usage](./src/hdTri/CMakeLists.txt)
+- `usd_executable`: [Example usage](./src/usdTri/CMakeLists.txt#45)
 - `usd_test`: [Example usage](./src/usdTri/tests/CMakeLists.txt)
 - `usd_python_library`: [Example usage](./src/usdviewTri/CMakeLists.txt)
 - `usd_python_test`: [Example usage](./src/usdTri/tests/CMakeLists.txt)

--- a/cmake/USDPluginTools.cmake
+++ b/cmake/USDPluginTools.cmake
@@ -178,6 +178,48 @@ function(usd_python_library NAME)
     endif()
 endfunction()
 
+# Adds a USD-based C++ executable application.
+function(usd_executable EXECUTABLE_NAME)
+
+    set(options)
+
+    set(oneValueArgs
+    )
+
+    set(multiValueArgs
+        CPPFILES
+        LIBRARIES
+        INCLUDE_DIRS
+    )
+
+    cmake_parse_arguments(args
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    # Define a new executable.
+    add_executable(${EXECUTABLE_NAME}
+        ${args_CPPFILES}
+    )
+
+    # Apply properties.
+    _usd_target_properties(${EXECUTABLE_NAME}
+        INCLUDE_DIRS
+            ${args_INCLUDE_DIRS}
+        LIBRARIES
+            ${args_LIBRARIES}
+    )
+
+    # Install built executable.
+    install(
+        TARGETS ${EXECUTABLE_NAME}
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+endfunction() # usd_executable
+
 # Adds a USD-based cpp test which is executed by CTest.
 function(usd_test TEST_TARGET)
 

--- a/src/usdTri/CMakeLists.txt
+++ b/src/usdTri/CMakeLists.txt
@@ -42,4 +42,16 @@ usd_shared_library(usdTri
         plugInfo.json
 )
 
+usd_executable(triangleCounter
+
+    CPPFILES
+        triangleCounter.cpp
+
+    LIBRARIES
+        tf
+        sdf
+        usd
+        usdTri
+)
+
 add_subdirectory(tests)

--- a/src/usdTri/triangleCounter.cpp
+++ b/src/usdTri/triangleCounter.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright © 2020 Weta Digital Limited
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/* A simple program which opens an input USD file, and prints
+ * the number of prims of type "Triangle" in the composed stage */
+
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/primRange.h>
+#include <usdpluginexamples/usdTri/triangle.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+int
+main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        printf("usage: triangleCounter <USD_FILE>\n");
+        return EXIT_FAILURE;
+    }
+
+    int triangleCount = 0;
+    UsdStageRefPtr stage = UsdStage::Open(argv[1]);
+    for (UsdPrim prim : stage->TraverseAll()) {
+        if (prim.IsA<UsdTriTriangle>()) {
+            triangleCount++;
+        }
+    }
+
+    printf("Number of triangles: %i\n", triangleCount);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Included a "triangleCounter" executable example which counts
the number of Triangle prims in a usd file.

Signed-off-by: rlei-weta <rlei@wetafx.co.nz>