### PR TITLE
usd_python_test now expects explicit test target name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Custom CMake functions are provided, for abstracting away USD plugin build intri
 - `usd_library`: [Example usage](./src/usdTri/CMakeLists.txt)
 - `usd_plugin`: [Example usage](./src/hdTri/CMakeLists.txt)
 - `usd_executable`: [Example usage](./src/usdTri/CMakeLists.txt#L45)
-- `usd_test`: [Example usage](./src/usdTri/tests/CMakeLists.txt#L3)
+- `usd_test`: [Example usage](./src/usdTri/tests/CMakeLists.txt#L5)
 - `usd_python_library`: [Example usage](./src/usdviewTri/CMakeLists.txt)
 - `usd_python_test`: [Example usage](./src/usdTri/tests/CMakeLists.txt#L1)
 

--- a/cmake/USDPluginTools.cmake
+++ b/cmake/USDPluginTools.cmake
@@ -276,7 +276,7 @@ endfunction()
 # Adds a USD-based python test which is executed by CTest.
 # The python file is simply executed by the python interpreter
 # with no special arguments.
-function(usd_python_test TEST_PREFIX PYTHON_FILE)
+function(usd_python_test TEST_TARGET PYTHON_FILE)
     if (NOT ENABLE_PYTHON_SUPPORT)
         message(STATUS "ENABLE_PYTHON_SUPPORT is OFF, skipping python test: ${TEST_PREFIX} ${PYTHON_FILE}")
         return()
@@ -286,19 +286,16 @@ function(usd_python_test TEST_PREFIX PYTHON_FILE)
         return()
     endif()
 
-    # Create a test target based on a named test prefix
-    # and the python file name.
-    get_filename_component(TEST_NAME ${PYTHON_FILE} NAME_WE)
-    set(PYTHON_TEST_TARGET ${TEST_PREFIX}_${TEST_NAME})
+    # Add a new test target.
     add_test(
-        NAME ${PYTHON_TEST_TARGET}
+        NAME ${TEST_TARGET}
         COMMAND ${PYTHON_EXECUTABLE} ${PYTHON_FILE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
     # Set-up runtime environment variables for the test.
     # The paths refer to the build tree (which mirrors the final installation).
-    set_tests_properties(${PYTHON_TEST_TARGET}
+    set_tests_properties(${TEST_TARGET}
         PROPERTIES
             ENVIRONMENT
             "PYTHONPATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/python:${USD_ROOT}/${CMAKE_INSTALL_LIBDIR}/python:$ENV{PYTHONPATH};PXR_PLUGINPATH_NAME=${_TEST_PXR_PLUGIN_PATH}"

--- a/src/usdTri/tests/CMakeLists.txt
+++ b/src/usdTri/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
-usd_python_test(usdTri_python testTriangle.py)
+usd_python_test(usdTri_python_testTriangle
+    testTriangle.py
+)
 
 usd_test(usdTri_testTriangle
 


### PR DESCRIPTION
Signed-off-by: rlei-weta <rlei@wetafx.co.nz>