### PR TITLE
Added minimum MSVC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ cmake \
 cmake --build  . -- VERBOSE=1 -j8 all test install
 ```
 
+Example snippet for generating a Visual Studio project on Windows:
+```cmd
+mkdir build
+cd build
+cmake ^
+    .. ^
+    -G "Visual Studio 15 2017 Win64" ^
+    -DCMAKE_INSTALL_PREFIX=D:\usd\USDPluginExamples\ ^
+    -DUSE_PYTHON_3=ON ^
+    -DBUILD_TESTING=ON ^
+    -DUSD_ROOT="D:\usd\builds\v20.11" ^
+    -DTBB_ROOT="D:\usd\builds\v20.11" ^
+    -DBOOST_ROOT="D:\usd\builds\v20.11"
+```
+
+
 CMake options for configuring this project:
 
 | CMake Variable name     | Description                                                            | Default |
@@ -72,12 +88,22 @@ To register the plugin(s) as part of the USD runtime, the following environment 
 to be defined:
 | Environment Variable  | Value(s)                                                                                 |
 | --------------------- | ---------------------------------------------------------------------------------------- |
-| `LD_LIBRARY_PATH`     | `${USDPLUGINEXAMPLES_INSTALL_ROOT}/lib`                                                  |
 | `PYTHONPATH`          | `${USDPLUGINEXAMPLES_INSTALL_ROOT}/lib/python`                                           |
 | `PXR_PLUGINPATH_NAME` | `${USDPLUGINEXAMPLES_INSTALL_ROOT}/lib/usd`<br/>`${USDPLUGINEXAMPLES_INSTALL_ROOT}/plugin/usd` |
 
+Additionally, Windows requires:
+| Environment Variable  | Value(s)                                                                                 |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `PATH`                | `${USDPLUGINEXAMPLES_INSTALL_ROOT}/lib`                                                  |
+
+Additionally, Linux requires:
+| Environment Variable  | Value(s)                                                                                 |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `LD_LIBRARY_PATH`     | `${USDPLUGINEXAMPLES_INSTALL_ROOT}/lib`                                                  |
+
 <sub>Note: libraries and plugins are installed into different locations - thus PXR_PLUGINPATH_NAME specifies
 two separate values.</sub>
+
 
 Once the environment variables have been set-up, an example scene in this repo can be previewed with **usdview**:
 ```

--- a/cmake/packages/FindUSD.cmake
+++ b/cmake/packages/FindUSD.cmake
@@ -8,6 +8,11 @@ message(STATUS ${USD_ROOT})
 
 set(PXR_LIB_PREFIX "lib")
 
+if (MSVC)
+    # MSVC does not use prefixes for libs
+    set(PXR_LIB_PREFIX "")
+endif()
+
 find_path(USD_INCLUDE_DIR pxr/pxr.h
           PATHS ${USD_ROOT}/include
                 $ENV{USD_ROOT}/include

--- a/src/usdTri/CMakeLists.txt
+++ b/src/usdTri/CMakeLists.txt
@@ -15,6 +15,7 @@ usd_library(usdTri
         gf
         usd
         usdGeom
+        arch
 
     PUBLIC_CLASSES
         triangle

--- a/src/usdTriFileFormat/CMakeLists.txt
+++ b/src/usdTriFileFormat/CMakeLists.txt
@@ -11,6 +11,7 @@ usd_plugin(usdTriFileFormat
         pcp
         usd
         usdGeom
+        arch
 
     RESOURCE_FILES
         plugInfo.json


### PR DESCRIPTION
Modified the minimum amount of code necessary to get this project to build on Windows through MSVC.

One known error that occurs at this point is that a python error is raised in both runtime and testing:

> ImportError: cannot import name '_usdTri' from 'usdpluginexamples.UsdTri' (D:\usd_projects\USDPluginExamples\20.11_windows_compatibility_install\lib\python\usdpluginexamples\UsdTri\__init__.py)
> Loading plugin 'usdImaging'.

Otherwise, however the other parts of this plugin appear to work as expected.