### PR TITLE
Fixed broken tests for MSVC and refactored set_tests_properties calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cmake \
 cmake --build  . -- VERBOSE=1 -j8 all test install
 ```
 
-Example snippet for generating a Visual Studio project on Windows:
+Example snippet for building a Visual Studio project on Windows:
 ```cmd
 mkdir build
 cd build
@@ -68,6 +68,8 @@ cmake ^
     -DUSD_ROOT="D:\usd\builds\v20.11" ^
     -DTBB_ROOT="D:\usd\builds\v20.11" ^
     -DBOOST_ROOT="D:\usd\builds\v20.11"
+
+cmake --build . --config Release -j 8 --target ALL_BUILD RUN_TESTS INSTALL
 ```
 
 


### PR DESCRIPTION
- Renamed .dll to .pyd for MSVC
- Refactored set_tests_properties to be in one place for all platforms
- Fixed issues with build unable to test BEFORE install on MSVC

Signed-off-by: Cole Clark <colevfx@gmail.com>