### PR TITLE
Added Windows CI Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,88 @@ jobs:
         run: ctest -VV --output-on-failure -C ${{ matrix.buildType }}
         working-directory: _build
 
+
+# A build job matrix based on pre-built USD binaries provided by NVIDIA on Windows.
+  nvidia-usd-binaries-windows-build:
+    strategy:
+      matrix:
+        usdVersion:
+          - 20.08
+          - 20.11
+          - 21.02
+        include:
+          - usdVersion: 20.08
+            usdVersionUrl: 20.08
+            pythonVersion: 3.6
+            USE_PYTHON_3: ON
+            buildType: Release
+            buildTests: ON
+          - usdVersion: 20.11
+            usdVersionUrl: 20-11
+            pythonVersion: 3.6
+            USE_PYTHON_3: ON
+            buildType: Release
+            buildTests: ON
+          - usdVersion: 21.02
+            usdVersionUrl: 21-02
+            pythonVersion: 3.6
+            USE_PYTHON_3: ON
+            buildType: Release
+            buildTests: ON
+    runs-on: windows-2016
+    name: 'Windows 2016 NVIDIA Pre-built Binaries
+      <USD Version=${{ matrix.usdVersion }},
+       Python Version=${{ matrix.pythonVersion }},
+       Build type:${{ matrix.buildType }},
+       Enable tests=${{ matrix.build-tests }}>'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.pythonVersion }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.pythonVersion }}
+      - name: Download and extract pre-built USD binaries
+        run: |
+          Invoke-WebRequest https://developer.nvidia.com/usd-${{ matrix.usdVersionUrl }}-binary-windows-python-${{ matrix.pythonVersion }} -OutFile $env:TEMP/usd-${{ matrix.usdVersion }}.zip
+          mkdir -Force $env:TEMP/usd-${{ matrix.usdVersion }}
+          7z x $env:TEMP/usd-${{ matrix.usdVersion }}.zip $("-o" + "$env:TEMP" + "\usd-${{ matrix.usdVersion }}") -y
+      - name: Create build directories
+        run: |
+          mkdir -Force _build
+          mkdir -Force _install
+      - name: Configure
+        run: |
+          cmake -DUSD_ROOT="$env:TEMP/usd-${{ matrix.usdVersion }}" `
+              -DTBB_ROOT="$env:TEMP/usd-${{ matrix.usdVersion }}" `
+              -DBOOST_ROOT="$env:TEMP/usd-${{ matrix.usdVersion }}" `
+              -DUSE_PYTHON_3=${{ matrix.USE_PYTHON_3 }} `
+              -DCMAKE_BUILD_TYPE=${{ matrix.buildType }} `
+              -DBUILD_TESTING=${{ matrix.buildTests }} `
+              -DCMAKE_INSTALL_PREFIX="../_install" `
+              -G "Visual Studio 15 2017 Win64" `
+              ..
+        working-directory: "_build"
+      - name: Build
+        run: |
+          cmake --build . `
+            --verbose `
+            --config ${{ matrix.buildType }} `
+            --target ALL_BUILD
+        working-directory: "_build"
+      - name: Run Tests
+        run: |
+          ctest --extra-verbose `
+            --output-on-failure `
+            -C ${{ matrix.buildType }}
+        working-directory: "_build"
+      - name: Install
+        run: |
+          cmake --build . `
+            --verbose `
+            --config ${{ matrix.buildType }} `
+            --target INSTALL
+        working-directory: "_build"
+
   # ASWF docker images based build
   aswf-build:
     strategy:

--- a/cmake/Packages.cmake
+++ b/cmake/Packages.cmake
@@ -4,11 +4,11 @@
 if (ENABLE_PYTHON_SUPPORT)
     # Find python libraries.
     if (USE_PYTHON_3)
-        find_package(PythonLibs 3.0 REQUIRED)
         find_package(PythonInterp 3.0 REQUIRED)
+        find_package(PythonLibs 3.0 REQUIRED)
     else()
-        find_package(PythonLibs 2.7 REQUIRED)
         find_package(PythonInterp 2.7 REQUIRED)
+        find_package(PythonLibs 2.7 REQUIRED)
     endif()
 
     # Pick up boost version variables.

--- a/cmake/USDPluginTools.cmake
+++ b/cmake/USDPluginTools.cmake
@@ -834,6 +834,8 @@ function(_usd_set_test_properties
         string(PREPEND TEST_PATH "\\;")
         list(APPEND TEST_PATH 
             "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
+            "${USD_ROOT}/${CMAKE_INSTALL_LIBDIR}"
+            "${USD_ROOT}/${CMAKE_INSTALL_BINDIR}"
         )
 
         list(APPEND TEST_ENV_VARS "${TEST_PATH}")


### PR DESCRIPTION
Addressed PR notes from:
https://github.com/wetadigital/USDPluginExamples/pull/29

- Removed unnecessary set env var commands from CI tests.
- Added missing required env vars to ctests
- Refactored CI names, extra whitespace.

Previous Comments:
- Added Windows Companion to Linux Prebuilt-binary tests
- Fixed issue with reversed findPythonInterp and findPythonLibs cmds

Signed-off-by: Cole Clark <colevfx@gmail.com>