### PR TITLE
Don't set VERSION/SOVERSION for APPLE libraries

### DIFF
--- a/cmake/USDPluginTools.cmake
+++ b/cmake/USDPluginTools.cmake
@@ -417,11 +417,13 @@ function(_usd_cpp_library NAME)
     else()
         # Setup SOVERSION & VERSION properties to create
         # NAMELINK, SONAME, and actual library with full version suffix.
-        set_target_properties(${NAME}
-            PROPERTIES
-                SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
-                VERSION ${CMAKE_PROJECT_VERSION}
-        )
+        if (!APPLE)
+            set_target_properties(${NAME}
+                PROPERTIES
+                    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+                    VERSION ${CMAKE_PROJECT_VERSION}
+            )
+        endif()
 
         # Install the library and export it as an public target.
         install(


### PR DESCRIPTION

**Issue:** 
When a plugin is attempted to be loaded but it can't be found due to the naming of the file on OSX (Ventura)
`Error in 'pxrInternal_v0_23__pxrReserved__::PlugPlugin::_Load' at line 261 in file [.....]/USD/23.05/pxr/base/plug/plugin.cpp : 'Failed to load plugin 'usdTri': dlopen([.....]/UsdPluginExamples/build_23.05/lib/libusdTri.dylib, 0x0002): tried: '[.....]/UsdPluginExamples/build_23.05/lib/libusdTri.dylib' (no such file), '[.....]/UsdPluginExamples/build_23.05/lib/libusdTri.dylib' (no such file), '[.....]/UsdPluginExamples/build_23.05/lib/libusdTri.dylib' (no such file), '[.....]/USDPluginExamples/build_23.05/lib/libusdTri.dylib' (no such file), '[.....]/USDPluginExamples/build_23.05/lib/libusdTri.dylib' (no such file), '[.....]/USDPluginExamples/build_23.05/lib/libusdTri.dylib' (no such file) in '[.....]/UsdPluginExamples/build_23.05/lib/libusdTri.dylib'`

The file is actually called `libusdTri.0.0.0.dylib`

This PR is fixing the issue for Apple 