### PR TITLE
Disable /Zc:inline option for MSVC 2019 and above

### DIFF
--- a/cmake/Defaults.cmake
+++ b/cmake/Defaults.cmake
@@ -12,3 +12,20 @@ if (BUILD_TESTING)
     # Be very verbose on test failure.
     list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 endif()
+
+if (MSVC)
+    # From OpenUSD/cmake/defaults/msvcdefaults.cmake
+    #
+    # The /Zc:inline option strips out the "arch_ctor_<name>" symbols used for
+    # library initialization by ARCH_CONSTRUCTOR starting in Visual Studio 2019,
+    # causing release builds to fail. Disable the option for this and later
+    # versions.
+    #
+    # For more details, see:
+    # https://developercommunity.visualstudio.com/content/problem/914943/zcinline-removes-extern-symbols-inside-anonymous-n.html
+    if (MSVC_VERSION GREATER_EQUAL 1920)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:inline-")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:inline")
+    endif()
+endif()


### PR DESCRIPTION
Thanks @OleksiyPuzikov for pointing this one out!